### PR TITLE
更新了gbt7714-numerical,修复了旧版本的期刊名为斜体的问题

### DIFF
--- a/gbt7714-numerical.bst
+++ b/gbt7714-numerical.bst
@@ -8,9 +8,9 @@
 %% -------------------------------------------------------------------
 %% GB/T 7714 BibTeX Style
 %% https://github.com/zepinglee/gbt7714-bibtex-style
-%% Version: 2021/12/08 v2.1.3
+%% Version: 2024/03/08 v2.1.6
 %% -------------------------------------------------------------------
-%% Copyright (C) 2016—2021 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016--2024 by Zeping Lee <zepinglee AT gmail.com>
 %% -------------------------------------------------------------------
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
@@ -37,10 +37,9 @@ INTEGERS {
   show.mark
   space.before.mark
   show.medium.type
-  slash.for.extraction
-  in.booktitle
   short.journal
   italic.journal
+  link.journal
   bold.journal.volume
   show.missing.address.publisher
   space.before.pages
@@ -55,37 +54,41 @@ INTEGERS {
   end.with.period
 }
 
+STRINGS {
+  component.part.label
+}
+
 FUNCTION {load.config}
 {
   #2 'citation.et.al.min :=
   #1 'citation.et.al.use.first :=
   #4 'bibliography.et.al.min :=
   #3 'bibliography.et.al.use.first :=
-  #0 'uppercase.name :=
+  #1 'uppercase.name :=
   #0 'terms.in.macro :=
   #0 'year.after.author :=
   #1 'period.after.author :=
-  #1 'italic.book.title :=
-  #0 'sentence.case.title :=
-  #1 'link.title :=
+  #0 'italic.book.title :=
+  #1 'sentence.case.title :=
+  #0 'link.title :=
   #1 'title.in.journal :=
   #0 'show.patent.country :=
   #1 'show.mark :=
   #0 'space.before.mark :=
   #1 'show.medium.type :=
-  #1 'slash.for.extraction :=
-  #0 'in.booktitle :=
+  "slash" 'component.part.label :=
   #0 'short.journal :=
-  #1 'italic.journal :=
+  #0 'italic.journal :=
+  #0 'link.journal :=
   #0 'bold.journal.volume :=
   #0 'show.missing.address.publisher :=
   #1 'space.before.pages :=
   #0 'only.start.page :=
   #0 'wave.dash.in.pages :=
   #1 'show.urldate :=
-  #0 'show.url :=
-  #0 'show.doi :=
-  #0 'show.preprint :=
+  #1 'show.url :=
+  #1 'show.doi :=
+  #1 'show.preprint :=
   #0 'show.note :=
   #0 'show.english.translation :=
   #1 'end.with.period :=
@@ -102,6 +105,7 @@ ENTRY
     editor
     eprint
     eprinttype
+    entrysubtype
     howpublished
     institution
     journal
@@ -382,9 +386,22 @@ FUNCTION {new.sentence}
 FUNCTION {new.slash}
 { output.state before.all =
     'skip$
-    { slash.for.extraction
+    { component.part.label "slash" =
         { after.slash 'output.state := }
-        { after.block 'output.state := }
+        { new.block
+          component.part.label "in" =
+            { entry.lang lang.en =
+                { "In: " output
+                  write$
+                  ""
+                  before.all 'output.state :=
+                }
+                'skip$
+              if$
+            }
+            'skip$
+          if$
+        }
       if$
     }
   if$
@@ -720,7 +737,7 @@ FUNCTION {editor.full}
 
 FUNCTION {make.full.names}
 { type$ "book" =
-  type$ "inbook" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.full
     { type$ "collection" =
@@ -862,7 +879,7 @@ FUNCTION {format.volume}
     { volume is.number
         { entry.lang lang.zh =
             { "第 " volume * " 卷" * }
-            { "volume" volume tie.or.space.connect }
+            { "Vol." volume tie.or.space.connect }
           if$
         }
         { volume }
@@ -877,7 +894,7 @@ FUNCTION {format.number}
     { number is.number
         { entry.lang lang.zh =
             { "第 " number * " 册" * }
-            { "number" number tie.or.space.connect }
+            { "No." number tie.or.space.connect }
           if$
         }
         { number }
@@ -977,14 +994,6 @@ FUNCTION {format.series.vol.num.booktitle}
     { format.booktitle.vol.num }
   if$
   format.btitle
-  in.booktitle
-    { duplicate$ empty$ not entry.lang lang.en = and
-        { "In: " swap$ * }
-        'skip$
-      if$
-    }
-    'skip$
-  if$
 }
 
 FUNCTION {remove.period}
@@ -1050,7 +1059,7 @@ FUNCTION {get.journal.title}
 }
 
 FUNCTION {check.arxiv.preprint}
-{ #1 #5 substring$ "l" change.case$ "arxiv" =
+{ #1 #5 substring$ purify$ "l" change.case$ "arxiv" =
     { #1 }
     { #0 }
   if$
@@ -1061,6 +1070,10 @@ FUNCTION {format.journal}
   duplicate$ empty$ not
     { italic.journal entry.lang lang.en = and
         'emphasize
+        'skip$
+      if$
+      link.journal
+        'add.link
         'skip$
       if$
     }
@@ -1126,9 +1139,13 @@ FUNCTION {format.edition}
 { edition empty$
     { "" }
     { edition is.number
-        { entry.lang lang.zh =
-            { edition " 版" * }
-            { edition num.to.ordinal " ed." * }
+        { edition "1" = not
+            { entry.lang lang.zh =
+                { edition " 版" * }
+                { edition num.to.ordinal " ed." * }
+              if$
+            }
+            'skip$
           if$
         }
         { entry.lang lang.en =
@@ -1290,7 +1307,10 @@ FUNCTION {format.year}
     { year extract.before.slash extra.label * }
     { date empty$ not
         { date extract.before.dash extra.label * }
-        { "empty year in " cite$ * warning$
+        { entry.is.electronic not
+            { "empty year in " cite$ * warning$ }
+            'skip$
+          if$
           urldate empty$ not
             { "[" urldate extract.before.dash * extra.label * "]" * }
             { "" }
@@ -1328,7 +1348,15 @@ FUNCTION {format.date}
 { date empty$ not
     { type$ "patent" = type$ "newspaper" = or
         { date }
-        { format.year }
+        { entrysubtype empty$ not
+            { type$ "article" = entrysubtype "newspaper" = and
+                { date }
+                { format.year }
+              if$
+            }
+            { format.year }
+          if$
+        }
       if$
     }
     { year empty$ not
@@ -1796,7 +1824,15 @@ FUNCTION {journal.article}
   new.block
   title.in.journal
     { format.title "title" output.check
-      "J" set.entry.mark
+      entrysubtype empty$ not
+        {
+          entrysubtype "newspaper" =
+            { "N" set.entry.mark }
+            { "J" set.entry.mark }
+          if$
+        }
+        { "J" set.entry.mark }
+      if$
       format.mark "" output.after
       new.block
     }
@@ -1936,6 +1972,10 @@ FUNCTION {preprint}
   format.urldate "" output.after
   output.eprint
   output.url
+  show.preprint not eprint empty$ or
+    'output.doi
+    'skip$
+  if$
   new.block
   format.note output
   fin.entry
@@ -2000,7 +2040,12 @@ FUNCTION {dataset}
   electronic
 }
 
-FUNCTION {inbook} { book }
+FUNCTION {inbook} {
+  booktitle empty$
+    'book
+    'incollection
+  if$
+}
 
 FUNCTION {inproceedings}
 { "C" set.entry.mark
@@ -2241,7 +2286,7 @@ FUNCTION {editor.key.organization.label}
 FUNCTION {calc.short.authors}
 { "" 'short.label :=
   type$ "book" =
-  type$ "inbook" =
+  type$ "inbook" = booktitle empty$ not and
   or
     'author.editor.key.label
     { type$ "collection" =


### PR DESCRIPTION
修改的 gbt7714-numerical.bst 文件来自库 [zepinglee/gbt7714-bibtex-style](https://github.com/zepinglee/gbt7714-bibtex-style)中最新的 v2.1.6 版本